### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 
+<a href="https://glama.ai/mcp/servers/@andreax79/otp-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@andreax79/otp-mcp/badge" alt="otp-mcp-server MCP server" />
+</a>
+
 Model Context Protocol (MCP) server that provides OTP (One-Time Password) generation
 
 A Model Context Protocol (MCP) server built with FastMCP


### PR DESCRIPTION
This PR adds a badge for the [otp-mcp-server](https://glama.ai/mcp/servers/@andreax79/otp-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@andreax79/otp-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@andreax79/otp-mcp/badge" alt="otp-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.